### PR TITLE
get_recommendations bug fix

### DIFF
--- a/R/authenticate.R
+++ b/R/authenticate.R
@@ -39,7 +39,7 @@ get_spotify_access_token <- function(client_id = Sys.getenv('SPOTIFY_CLIENT_ID')
 #' @export
 #' @examples
 #' \donttest{
-#' get_spotify_authorization_code()
+#' ## get_spotify_authorization_code()
 #' }
 
 get_spotify_authorization_code <- function(

--- a/R/browse.R
+++ b/R/browse.R
@@ -233,7 +233,7 @@ get_featured_playlists <- function(locale = NULL, country = NULL, timestamp = NU
 #' @examples
 #' \donttest{
 #' ## Get new Swedish music
-#' get_recommendations(country = 'SE')
+#' get_recommendations(market = 'SE')
 #' }
 
 get_recommendations <- function(limit = 20,

--- a/R/browse.R
+++ b/R/browse.R
@@ -68,13 +68,12 @@ get_category <- function(category_id, country = NULL, locale = NULL, authorizati
 #' @param include_meta_info Optional. Boolean indicating whether to include full result, with meta information such as \code{"total"}, and \code{"limit"}. Defaults to \code{FALSE}.
 #' @return
 #' Returns a data frame of results containing category playlists. See \url{https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/} for more information.
-#' @export
-#'
 #' @examples
 #' \donttest{
 #' ## Get Brazilian party playlists
 #' get_category_playlists('party', country = 'BR')
 #' }
+#' @export
 
 get_category_playlists <- function(category_id, country = NULL, limit = 20, offset = 0, authorization = get_spotify_access_token(), include_meta_info = FALSE) {
     base_url <- 'https://api.spotify.com/v1/browse/categories'
@@ -228,13 +227,10 @@ get_featured_playlists <- function(locale = NULL, country = NULL, timestamp = NU
 #' @return
 #' Returns a data frame of results recommendations. See the official
 #' \href{https://developer.spotify.com/documentation/web-api/reference/#category-search}{Spotify Web API documentation} for more information.
-#' @export
-#'
 #' @examples
-#' \donttest{
-#' ## Get new Swedish music
-#' get_recommendations(market = 'SE')
-#' }
+#' \donttest{ get_recommendations(market = 'SE') }
+#' @family personalization functions
+#' @export
 
 get_recommendations <- function(limit = 20,
                                 market = NULL,
@@ -354,25 +350,28 @@ get_recommendations <- function(limit = 20,
 
 #' Get recommendations for a submitted vector of track IDs, with no limit on the number of seed tracks
 #'
-#' @description
-#' This is a wrapper for the get_recommendations() function, which provides a workaround for the limit of 5 seed tracks per recommendation call. The function splits a supplied vector of track IDs into subsets of length 5, then applies a get_recommendations() call, 5 tracks at a time. This should generate a data frame of recommended tracks, with length equal to the supplied vector of track ids.
-#'
+#' This is a wrapper for the \code{\link{get_recommendations()}} function, which provides a workaround for
+#' the limit of 5 seed tracks per recommendation call. The function splits a supplied vector
+#' of track IDs into subsets of length 5, then applies a get_recommendations() call,
+#' 5 tracks at a time. This should generate a data frame of recommended tracks, with
+#' length equal to the supplied vector of track ids.
 #'
 #' @param track_ids
 #' A vector containing the IDs of the tracks you'd like recommendations for
 #' @param valence
 #' The target valence for the recommendations
-#'
 #' @return
 #' Returns a data frame containing recommendations from the Spotify API
-#' @export
-#'
 #' @examples
 #' \donttest{
 #' get_recommendations_all(c("5VIpLopHgolKcSSj7JPCMA", "3QRGYDFFUVb4qneE4DX1gR"))
 #' }
+#' @family personalization functions
+#' @export
+
 
 get_recommendations_all <- function(track_ids, valence = NULL) {
+
     get_recs <- function(i, ids, vec_length, valence) {
         start <- i
         end <- ifelse(i + 4 > vec_length, vec_length, i+4)
@@ -384,7 +383,11 @@ get_recommendations_all <- function(track_ids, valence = NULL) {
     }
 
     tracks_length <- length(track_ids)
-    tracks_seq <- seq(from = 1, to = tracks_length, by = 5)
+
+    tracks_seq <- seq(from = 1,
+                      to = tracks_length,
+                      by = 5)
+
     all_recs <- map_df(tracks_seq,
                        ~ get_recs(.x, track_ids, tracks_length, valence))
     all_recs

--- a/R/browse.R
+++ b/R/browse.R
@@ -169,6 +169,9 @@ get_featured_playlists <- function(locale = NULL, country = NULL, timestamp = NU
 
 #' Create a playlist-style listening experience based on seed artists, tracks and genres.
 #'
+#' All parameters are optional, but at least one of
+#' \code{seed_artists}, \code{seed_tracks} and \code{seed_genres} must be given.
+#'
 #' @param limit Optional. The target size of the list of recommended tracks. For seeds with unusually small pools or when highly restrictive filtering is applied, it may be impossible to generate the requested number of recommended tracks. Debugging information for such cases is available in the response. Default: 20. Minimum: 1. Maximum: 100.
 #' @param market Optional.
 #' An \href{https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2}{ISO 3166-1 alpha-2 country code} or the string \code{from_token}.
@@ -228,7 +231,7 @@ get_featured_playlists <- function(locale = NULL, country = NULL, timestamp = NU
 #' Returns a data frame of results recommendations. See the official
 #' \href{https://developer.spotify.com/documentation/web-api/reference/#category-search}{Spotify Web API documentation} for more information.
 #' @examples
-#' \donttest{ get_recommendations(market = 'SE') }
+#' \donttest{ get_recommendations(market = 'SE', seed_genres = 'rock') }
 #' @family personalization functions
 #' @export
 
@@ -284,6 +287,10 @@ get_recommendations <- function(limit = 20,
 
     if (length(seed_artists) + length(seed_tracks) + length(seed_genres) > 5) {
         stop("Too many seed values. Up to 5 seed values may be provided in any combination of seed_artists, seed_tracks and seed_genres")
+    }
+
+    if ( all(is.null(seed_artists), is.null(seed_genres), is.null(seed_tracks)) ) {
+        stop ( "At least one of seed_artists, seed_genres or seed_tracks must be given." )
     }
 
     base_url <- 'https://api.spotify.com/v1/recommendations'
@@ -350,9 +357,9 @@ get_recommendations <- function(limit = 20,
 
 #' Get recommendations for a submitted vector of track IDs, with no limit on the number of seed tracks
 #'
-#' This is a wrapper for the \code{\link{get_recommendations()}} function, which provides a workaround for
+#' This is a wrapper for the \code{\link{get_recommendations}} function, which provides a workaround for
 #' the limit of 5 seed tracks per recommendation call. The function splits a supplied vector
-#' of track IDs into subsets of length 5, then applies a get_recommendations() call,
+#' of track IDs into subsets of length 5, then applies a  \code{\link{get_recommendations}} call,
 #' 5 tracks at a time. This should generate a data frame of recommended tracks, with
 #' length equal to the supplied vector of track ids.
 #'
@@ -364,7 +371,9 @@ get_recommendations <- function(limit = 20,
 #' Returns a data frame containing recommendations from the Spotify API
 #' @examples
 #' \donttest{
-#' get_recommendations_all(c("5VIpLopHgolKcSSj7JPCMA", "3QRGYDFFUVb4qneE4DX1gR"))
+#' get_recommendations_all(
+#'    track_ids = c("5VIpLopHgolKcSSj7JPCMA", "3QRGYDFFUVb4qneE4DX1gR")
+#'    )
 #' }
 #' @family personalization functions
 #' @export

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -15,7 +15,8 @@
 #' @param dedupe_albums Optional. Boolean.
 #' @param authorization Required. A valid access token from the Spotify Accounts service.
 #' See the
-#' \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}
+#' \href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details.
+#' Defaults to \code{spotifyr::get_spotify_access_token()}
 #' @return
 #' Returns a data frame of results containing track audio features data. See the
 #' \href{https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/}{Spotify Web API documentation} for more information.

--- a/R/geniusR.R
+++ b/R/geniusR.R
@@ -1,7 +1,8 @@
 #' Retrieve artist discography with song lyrics and audio info
 #'
 #' Retrieve the entire discography of an artist with the lyrics of each song and the
-#' associated audio information. Returns the song data as a nested tibble (see \code{tidyr::\link[tidyr]{nest}}).
+#' associated audio information. Returns the song data as a nested tibble
+#' (see \code{tidyr::\link[tidyr]{nest}}).
 #' This way we can easily see each album, artist, and song title before expanding our data.
 #'
 #' @param artist The quoted name of the artist. Spelling matters, capitalization does not.

--- a/man/get_album_data.Rd
+++ b/man/get_album_data.Rd
@@ -23,7 +23,8 @@ A nested tibble. See \code{tidyr::\link[tidyr]{nest}}.
 }
 \description{
 Retrieve the entire discography of an artist with the lyrics of each song and the
-associated audio information. Returns the song data as a nested tibble (see \code{tidyr::\link[tidyr]{nest}}).
+associated audio information. Returns the song data as a nested tibble
+(see \code{tidyr::\link[tidyr]{nest}}).
 This way we can easily see each album, artist, and song title before expanding our data.
 }
 \examples{

--- a/man/get_artist_audio_features.Rd
+++ b/man/get_artist_audio_features.Rd
@@ -32,7 +32,8 @@ For example: \code{include_groups = c("album", "single")}}
 
 \item{authorization}{Required. A valid access token from the Spotify Accounts service.
 See the
-\href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details. Defaults to \code{spotifyr::get_spotify_access_token()}}
+\href{https://developer.spotify.com/documentation/general/guides/authorization-guide/}{Web API authorization Guide} for more details.
+Defaults to \code{spotifyr::get_spotify_access_token()}}
 }
 \value{
 Returns a data frame of results containing track audio features data. See the

--- a/man/get_my_top_artists_or_tracks.Rd
+++ b/man/get_my_top_artists_or_tracks.Rd
@@ -47,4 +47,9 @@ See the official API
 \description{
 Get the current user’s top artists or tracks based on calculated affinity.
 }
+\seealso{
+Other personalization functions: 
+\code{\link{get_recommendations_all}()},
+\code{\link{get_recommendations}()}
+}
 \concept{personalization functions}

--- a/man/get_recommendations.Rd
+++ b/man/get_recommendations.Rd
@@ -171,6 +171,6 @@ Create a playlist-style listening experience based on seed artists, tracks and g
 \examples{
 \donttest{
 ## Get new Swedish music
-get_recommendations(country = 'SE')
+get_recommendations(market = 'SE')
 }
 }

--- a/man/get_recommendations.Rd
+++ b/man/get_recommendations.Rd
@@ -169,8 +169,11 @@ Returns a data frame of results recommendations. See the official
 Create a playlist-style listening experience based on seed artists, tracks and genres.
 }
 \examples{
-\donttest{
-## Get new Swedish music
-get_recommendations(market = 'SE')
+\donttest{ get_recommendations(market = 'SE') }
 }
+\seealso{
+Other personalization functions: 
+\code{\link{get_my_top_artists_or_tracks}()},
+\code{\link{get_recommendations_all}()}
 }
+\concept{personalization functions}

--- a/man/get_recommendations.Rd
+++ b/man/get_recommendations.Rd
@@ -166,10 +166,11 @@ Returns a data frame of results recommendations. See the official
 \href{https://developer.spotify.com/documentation/web-api/reference/#category-search}{Spotify Web API documentation} for more information.
 }
 \description{
-Create a playlist-style listening experience based on seed artists, tracks and genres.
+All parameters are optional, but at least one of
+\code{seed_artists}, \code{seed_tracks} and \code{seed_genres} must be given.
 }
 \examples{
-\donttest{ get_recommendations(market = 'SE') }
+\donttest{ get_recommendations(market = 'SE', seed_genres = 'rock') }
 }
 \seealso{
 Other personalization functions: 

--- a/man/get_recommendations_all.Rd
+++ b/man/get_recommendations_all.Rd
@@ -15,15 +15,17 @@ get_recommendations_all(track_ids, valence = NULL)
 Returns a data frame containing recommendations from the Spotify API
 }
 \description{
-This is a wrapper for the \code{\link{get_recommendations()}} function, which provides a workaround for
+This is a wrapper for the \code{\link{get_recommendations}} function, which provides a workaround for
 the limit of 5 seed tracks per recommendation call. The function splits a supplied vector
-of track IDs into subsets of length 5, then applies a get_recommendations() call,
+of track IDs into subsets of length 5, then applies a  \code{\link{get_recommendations}} call,
 5 tracks at a time. This should generate a data frame of recommended tracks, with
 length equal to the supplied vector of track ids.
 }
 \examples{
 \donttest{
-get_recommendations_all(c("5VIpLopHgolKcSSj7JPCMA", "3QRGYDFFUVb4qneE4DX1gR"))
+get_recommendations_all(
+   track_ids = c("5VIpLopHgolKcSSj7JPCMA", "3QRGYDFFUVb4qneE4DX1gR")
+   )
 }
 }
 \seealso{

--- a/man/get_recommendations_all.Rd
+++ b/man/get_recommendations_all.Rd
@@ -15,10 +15,20 @@ get_recommendations_all(track_ids, valence = NULL)
 Returns a data frame containing recommendations from the Spotify API
 }
 \description{
-This is a wrapper for the get_recommendations() function, which provides a workaround for the limit of 5 seed tracks per recommendation call. The function splits a supplied vector of track IDs into subsets of length 5, then applies a get_recommendations() call, 5 tracks at a time. This should generate a data frame of recommended tracks, with length equal to the supplied vector of track ids.
+This is a wrapper for the \code{\link{get_recommendations()}} function, which provides a workaround for
+the limit of 5 seed tracks per recommendation call. The function splits a supplied vector
+of track IDs into subsets of length 5, then applies a get_recommendations() call,
+5 tracks at a time. This should generate a data frame of recommended tracks, with
+length equal to the supplied vector of track ids.
 }
 \examples{
 \donttest{
 get_recommendations_all(c("5VIpLopHgolKcSSj7JPCMA", "3QRGYDFFUVb4qneE4DX1gR"))
 }
 }
+\seealso{
+Other personalization functions: 
+\code{\link{get_my_top_artists_or_tracks}()},
+\code{\link{get_recommendations}()}
+}
+\concept{personalization functions}

--- a/man/get_spotify_authorization_code.Rd
+++ b/man/get_spotify_authorization_code.Rd
@@ -23,7 +23,7 @@ This function creates a Spotify authorization code.
 }
 \examples{
 \donttest{
-get_spotify_authorization_code()
+## get_spotify_authorization_code()
 }
 }
 \keyword{auth}


### PR DESCRIPTION
Currently at least one type of seed must be given to the Web API.  Example failed in documentation.