### PR TITLE
Correct `scopes()` URL to fix `get_spotify_authorization_code()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -44,7 +44,7 @@ verify_result <- function(res) {
 #' @examples
 #' scopes()
 #' @return A character vector of valid authorization scopes for the Spotify Web API.
-#' See \href{https://developer.spotify.com/documentation/general/guides/scopes/}{Spotify Web API Authorization Scopes}
+#' See \href{https://developer.spotify.com/documentation/general/guides/authorization/scopes/}{Spotify Web API Authorization Scopes}
 #' @export
 #' @importFrom xml2 read_html
 #' @importFrom rvest html_text html_elements

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,7 +50,7 @@ verify_result <- function(res) {
 #' @importFrom rvest html_text html_elements
 
 scopes <- function() {
-    xml2::read_html("https://developer.spotify.com/documentation/general/guides/scopes/") %>%
+    xml2::read_html("https://developer.spotify.com/documentation/general/guides/authorization/scopes/") %>%
     rvest::html_elements('code') %>%
     rvest::html_text() %>%
     unique()


### PR DESCRIPTION
Corrects the URL referencing Spotify's Authorization Scopes, and closes issue #160 