### PR TITLE
Check for non-encoded character in `add_tracks_to_playlist()`

### DIFF
--- a/R/playlists.R
+++ b/R/playlists.R
@@ -327,7 +327,7 @@ create_playlist <- function(user_id,
 #' A maximum of 100 tracks can be added in one request.
 #' The uris will be formed as
 #' uris = c("spotify%3Atrack%3A61H97kuKIpi6kJQRnUEIlh", "spotify%3Atrack%3A2q6vlgBJ432KeZZNt2ZZBV").
-#' If you have the \code{"spotify:track:"} preffix in your vector it will
+#' If you have the \code{"spotify:track:"} prefix in your vector it will
 #' not be duplicated, otherwise it will be added.
 #' @param position Optional. Integer indicating the position to insert the tracks,
 #' a zero-based index. For example, to insert the tracks in the first position:

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -353,7 +353,7 @@ add_tracks_to_playlist <- function(playlist_id,
 
     uris <- ifelse ( ! grepl( "spotify%3Atrack%3A", gsub(":", "%3A", uris)),
              paste0("spotify%3Atrack%3A", uris),
-             uris)
+             gsub(":", "%3A", uris))
 
     base_url <- 'https://api.spotify.com/v1/playlists'
     url <- str_glue('{base_url}/{playlist_id}/tracks?uris={paste0(uris, collapse = ",")}')

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -351,7 +351,7 @@ add_tracks_to_playlist <- function(playlist_id,
                                    authorization = get_spotify_authorization_code()
                                    ) {
 
-    uris <- ifelse ( ! grepl( "spotify%3Atrack%3A", uris),
+    uris <- ifelse ( ! grepl( "spotify%3Atrack%3A", gsub(":", "%3A", uris)),
              paste0("spotify%3Atrack%3A", uris),
              uris)
 


### PR DESCRIPTION
Addresses issues #156 and #129.

`add_tracks_to_playlist()` was adding `spotify%3Atrack%3A` to the front of uris if the uri included the non-encoded `spotify:track:` version of the string. 

Update checks for both percent encoded and non-encoded versions and returns only encoded versions.
Also fixes typo in documentation.