### PR TITLE
Fixes a bug where playlists with 0 songs triggered subsequent page fetching and an error results

### DIFF
--- a/R/playlists.R
+++ b/R/playlists.R
@@ -58,11 +58,9 @@ get_playlist <- function(playlist_id, fields = NULL,
 
         # overwrite init_query item results
         init_query[["tracks"]][["items"]] <- all_items
-
-        #return init_query object
-        structure(init_query, class = c("playlist", "list"))
-
     }
+    #return init_query object
+    structure(init_query, class = c("playlist", "list"))
 }
 
 #' Get Details of User Playlist Tracks.

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -40,8 +40,9 @@ get_playlist <- function(playlist_id, fields = NULL,
 
     # stopping is built into query_playlist()
     init_query <- query_playlist(url, params = params)
-
+    # identify how many pages there are
     total_tracks <- pluck(init_query, "tracks", "total")
+    n_pages <- total_tracks %/% 100
     if (!is.null(fields) && !total_tracks > 100) {
         return(init_query)
     } else {

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -41,7 +41,8 @@ get_playlist <- function(playlist_id, fields = NULL,
     # stopping is built into query_playlist()
     init_query <- query_playlist(url, params = params)
 
-    if (!is.null(fields)) {
+    total_tracks <- pluck(init_query, "tracks", "total")
+    if (!is.null(fields) && !total_tracks > 100) {
         return(init_query)
     } else {
         # identify how many pages there are

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -42,12 +42,8 @@ get_playlist <- function(playlist_id, fields = NULL,
     init_query <- query_playlist(url, params = params)
     # identify how many pages there are
     total_tracks <- pluck(init_query, "tracks", "total")
-    n_pages <- total_tracks %/% 100
-    if (!is.null(fields) && !total_tracks > 100) {
-        return(init_query)
-    } else {
-        # identify how many pages there are
-        n_pages <- ceiling(pluck(init_query, "tracks", "total")/100) - 1
+    if (total_tracks > 100) {
+        n_pages <- total_tracks %/% 100
         # identify pagination offsets
         offsets <- seq(from = 1, to = n_pages) * 100
         # create page urls


### PR DESCRIPTION
Playlists with 0 songs triggered the fetching extra pages routine - this fixes that issue by making the conditional containing extra page fetching `TRUE` only when total tracks are greater than 100. 

Also:
 - Optimizes the `n_pages` computation
 - Preserves the "playlist" class of the output regardless of the result