### PR TITLE
Improves `add_songs_to_playlist` by allowing long lists of uris

### DIFF
--- a/R/playlists.R
+++ b/R/playlists.R
@@ -357,7 +357,8 @@ add_tracks_to_playlist <- function(playlist_id,
     url <- str_glue('{base_url}/{playlist_id}/tracks')
 
     params <- list(
-        position = position
+        position = position,
+        uris = uris
     )
 
     res <- RETRY('POST', url, body = params,

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -352,11 +352,9 @@ add_tracks_to_playlist <- function(playlist_id,
                                    ) {
 
     uris <- purrr::map_chr(uris, ~ifelse(stringr::str_detect(.x, "\\:"), .x, paste0("spotify:track:", .x)))
-             paste0("spotify%3Atrack%3A", uris),
-             gsub(":", "%3A", uris))
 
     base_url <- 'https://api.spotify.com/v1/playlists'
-    url <- str_glue('{base_url}/{playlist_id}/tracks?uris={paste0(uris, collapse = ",")}')
+    url <- str_glue('{base_url}/{playlist_id}/tracks')
 
     params <- list(
         position = position

--- a/R/playlists.R
+++ b/R/playlists.R
@@ -351,7 +351,7 @@ add_tracks_to_playlist <- function(playlist_id,
                                    authorization = get_spotify_authorization_code()
                                    ) {
 
-    uris <- ifelse ( ! grepl( "spotify%3Atrack%3A", gsub(":", "%3A", uris)),
+    uris <- purrr::map_chr(uris, ~ifelse(stringr::str_detect(.x, "\\:"), .x, paste0("spotify:track:", .x)))
              paste0("spotify%3Atrack%3A", uris),
              gsub(":", "%3A", uris))
 


### PR DESCRIPTION
As per the _Note_ on the [_Add Items to Playlist_ documentation](https://developer.spotify.com/documentation/web-api/reference/#/operations/add-tracks-to-playlist), query string length parameters can cause errors with long lists of URIs, so it's recommended to include json encoded uris as body parameters. 
This PR improves `add_songs_to_playlist` to follow this best practice