### PR TITLE
Remove reference to `preview_url`

### DIFF
--- a/R/extensions.R
+++ b/R/extensions.R
@@ -138,7 +138,6 @@ get_artist_audio_features <- function(artist = NULL,
             dplyr::rename(
               track_name = name,
               track_uri = uri,
-              #track_preview_url = preview_url, # Commented this out as it raises an error
               track_href = href,
               track_id = id
             )

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -138,7 +138,7 @@ get_artist_audio_features <- function(artist = NULL,
             dplyr::rename(
               track_name = name,
               track_uri = uri,
-              track_preview_url = preview_url,
+              #track_preview_url = preview_url, # Commented this out as it raises an error
               track_href = href,
               track_id = id
             )


### PR DESCRIPTION
The field `preview_url` does not appear to be returned for most artists, perhaps due to a change in the API. Requests that reference this field raise errors reported in https://github.com/charlie86/spotifyr/issues/202

This bug fix removes the offending line. The first commit commented it out for testing and the second removed the line entirely. I have tested the result and the code now works as expected.