### PR TITLE
Fix 'Illegal scopes' error

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -41,6 +41,7 @@ verify_result <- function(res) {
 #' A vector of valid scopes for \code{\link{get_spotify_authorization_code}}.
 #'
 #' @family authorization functions
+#' @param exclude_SOA Boolean indicating whether to exclude 'Spotify Open Access' (SOA) scopes, which are only available for approved partners. Defaults to \code{TRUE}.
 #' @examples
 #' scopes()
 #' @return A character vector of valid authorization scopes for the Spotify Web API.
@@ -49,12 +50,15 @@ verify_result <- function(res) {
 #' @importFrom xml2 read_html
 #' @importFrom rvest html_text html_elements
 
-scopes <- function() {
-    xml2::read_html("https://developer.spotify.com/documentation/general/guides/authorization/scopes/") %>%
-    rvest::html_elements('code') %>%
-    rvest::html_text() %>%
-    unique()
-    }
+scopes <- function(exclude_SOA = TRUE) {
+    res <-
+        xml2::read_html("https://developer.spotify.com/documentation/general/guides/authorization/scopes/") %>%
+        rvest::html_elements('code') %>%
+        rvest::html_text() %>%
+        unique()
+    if (exclude_SOA) res <- grep("soa", res, invert = TRUE, value = TRUE, fixed = TRUE)
+    res
+}
 
 #' Remove duplicate album names
 #'

--- a/man/scopes.Rd
+++ b/man/scopes.Rd
@@ -4,7 +4,10 @@
 \alias{scopes}
 \title{Valid Authorization Scopes}
 \usage{
-scopes()
+scopes(exclude_SOA = TRUE)
+}
+\arguments{
+\item{exclude_SOA}{Boolean indicating whether to exclude 'Spotify Open Access' (SOA) scopes, which are only available for approved partners. Defaults to \code{TRUE}.}
 }
 \value{
 A character vector of valid authorization scopes for the Spotify Web API.


### PR DESCRIPTION
Previously the `scopes()` function was failing for ordinary users because it tried to authorise SOA scopes which are not available except for select partners. I have fixed this behaviour by adding an `exclude_SOA` parameter, `TRUE` by default, which excludes these scopes and hence enables the authorisation to work by default.

Fixes #198.