### PR TITLE
Fix auto-unboxing issue in start_my_playback

### DIFF
--- a/R/player.R
+++ b/R/player.R
@@ -384,7 +384,7 @@ start_my_playback <- function(device_id = NULL,
   )
   body_params <- list(
     context_uri = context_uri,
-    uris = uris,
+    uris = I(uris),
     offset = offset,
     position_ms = position_ms
   )


### PR DESCRIPTION
Fixes #204, so that `start_my_playback` now works when `uris` has length 1.